### PR TITLE
⬆️ Update Vue and Vue Test Utils

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,13 @@
 module.exports = {
   'presets': [
-    [ '@babel/preset-env' ],
+    [
+      '@babel/preset-env',
+      {
+        'targets': {
+          'esmodules': true,
+        },
+      },
+    ],
   ],
   'env': {
     'test': {

--- a/example/main.js
+++ b/example/main.js
@@ -1,10 +1,10 @@
-import Vue from 'vue'
-import Demo from './Demo.vue'
+import Vue from 'vue';
+import Demo from './Demo.vue';
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
 /* eslint-disable no-new */
 new Vue({
   el: '#app',
-  render: h => h(Demo)
-})
+  render: h => h(Demo),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-1.5.0",
+  "version": "1.6.2-reedsy-1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/vuejs-datepicker",
-      "version": "1.6.2-reedsy-1.5.0",
+      "version": "1.6.2-reedsy-1.6.1",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.18.6"
@@ -21,7 +21,7 @@
         "@babel/preset-stage-2": "^7.0.0",
         "@babel/register": "^7.4.4",
         "@babel/runtime": "^7.18.6",
-        "@vue/test-utils": "^1.0.0-beta.12",
+        "@vue/test-utils": "^1.3.0",
         "autoprefixer": "^10.4.7",
         "babel-jest": "^24.8.0",
         "chalk": "^1.1.3",
@@ -52,14 +52,14 @@
         "rollup-plugin-replace": "^2.0.0",
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-terser": "^5.0.0",
-        "rollup-plugin-vue": "^5.0.0",
+        "rollup-plugin-vue": "4.7",
         "semver": "^5.3.0",
         "shelljs": "^0.8.3",
         "stylus": "^0.54.5",
-        "vue": "^2.6.10",
-        "vue-jest": "^4.0.0-beta.2",
-        "vue-server-renderer": "^2.6.10",
-        "vue-template-compiler": "^2.6.10"
+        "vue": "^2.7.4",
+        "vue-jest": "^4.0.1",
+        "vue-server-renderer": "^2.7.4",
+        "vue-template-compiler": "^2.7.4"
       },
       "peerDependencies": {
         "vue": "^2.6.10"
@@ -3765,22 +3765,16 @@
       "dev": true
     },
     "node_modules/@vue/component-compiler": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler/-/component-compiler-4.2.4.tgz",
-      "integrity": "sha512-tFGw3h3+nxiqnyborwWQ+rUgKAwSFl0Sdg+BCZkWTyFfkEF5fqunTNoklEUDdtRQMmVqsajn1pOZdm0zh4Uicw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler/-/component-compiler-3.6.0.tgz",
+      "integrity": "sha512-NIA0vmOI4zbtJAn69iZls8IJ8VxmguswAuiUdu8TcR+YYTYzntfw290HUCSFjzAdRg+FUWZv8r+wc3TzJ/IjwA==",
       "dev": true,
       "dependencies": {
-        "@vue/component-compiler-utils": "^3.0.0",
+        "@vue/component-compiler-utils": "^2.1.0",
         "clean-css": "^4.1.11",
         "hash-sum": "^1.0.2",
         "postcss-modules-sync": "^1.0.0",
         "source-map": "0.6.*"
-      },
-      "optionalDependencies": {
-        "less": "^3.9.0",
-        "pug": "^3.0.1",
-        "sass": "^1.18.0",
-        "stylus": "^0.54.5"
       },
       "peerDependencies": {
         "postcss": ">=6.0",
@@ -3829,17 +3823,96 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/@vue/test-utils": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.12.tgz",
-      "integrity": "sha512-457S/w+VuHnh4jw03ingrVAx8jMbxRz+jGGjoTeEFPZzv20GDzPUauQQqDy71EYw6BiNscC0RGOaLvAcS6BZ9Q==",
+    "node_modules/@vue/component-compiler/node_modules/@vue/component-compiler-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.4"
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^5.0.0",
+        "prettier": "1.16.3",
+        "source-map": "~0.6.1",
+        "vue-template-es2015-compiler": "^1.9.0"
+      }
+    },
+    "node_modules/@vue/component-compiler/node_modules/@vue/component-compiler-utils/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/@vue/component-compiler/node_modules/cssesc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+      "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@vue/component-compiler/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/@vue/component-compiler/node_modules/postcss-selector-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+      "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^2.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@vue/component-compiler/node_modules/prettier": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+      "integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
+      "dev": true,
+      "dependencies": {
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
       },
       "peerDependencies": {
         "vue": "2.x",
-        "vue-server-renderer": "2.x",
         "vue-template-compiler": "^2.x"
       }
     },
@@ -4120,13 +4193,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -4135,13 +4201,6 @@
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
-    },
-    "node_modules/assert-never": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -4369,19 +4428,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-walk": {
-      "version": "3.0.0-canary-5",
-      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@babel/types": "^7.9.6"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4773,16 +4819,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/character-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-regex": "^1.0.3"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4923,16 +4959,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -5106,17 +5132,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/constantinople": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.1"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -5247,25 +5262,13 @@
       }
     },
     "node_modules/css-selector-tokenizer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
       "dev": true,
       "dependencies": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
-      }
-    },
-    "node_modules/css-selector-tokenizer/node_modules/regexpu-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-      "dev": true,
-      "dependencies": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
       }
     },
     "node_modules/css-tree": {
@@ -5294,12 +5297,15 @@
       }
     },
     "node_modules/cssesc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssnano": {
@@ -5412,6 +5418,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
       "dev": true
     },
     "node_modules/dashdash": {
@@ -5609,12 +5621,11 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/doctypes": {
+    "node_modules/dom-event-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.1.0.tgz",
+      "integrity": "sha512-jNCX+uNJ3v38BKvPbpki6j5ItVlnSqVV6vDWGS6rExzCMjsc39frLjm1n91o6YaKK6AZl0wLloItW6C6mr61BQ==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -5752,7 +5763,7 @@
     "node_modules/emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -5777,19 +5788,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
       }
     },
     "node_modules/error-ex": {
@@ -8232,7 +8230,7 @@
     "node_modules/generic-names": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
-      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
+      "integrity": "sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==",
       "dev": true,
       "dependencies": {
         "loader-utils": "^0.2.16"
@@ -8746,26 +8744,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-size": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -8900,6 +8878,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA==",
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -9120,30 +9104,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-expression": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/is-expression/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -9251,13 +9211,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/is-reference": {
       "version": "1.1.2",
@@ -13688,9 +13641,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "node_modules/js-beautify": {
@@ -13719,13 +13672,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/js-tokens": {
       "version": "3.0.2",
@@ -13866,7 +13812,7 @@
     "node_modules/json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -13885,17 +13831,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/jstransformer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -13924,32 +13859,6 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
-    },
-    "node_modules/less": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
-      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "clone": "^2.1.2"
-      },
-      "bin": {
-        "lessc": "bin/lessc"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "optionalDependencies": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "mime": "^1.4.1",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
-        "request": "^2.83.0",
-        "source-map": "~0.6.0"
-      }
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -14030,7 +13939,7 @@
     "node_modules/loader-utils": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
       "dev": true,
       "dependencies": {
         "big.js": "^3.1.3",
@@ -14162,12 +14071,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-dir": {
@@ -14360,19 +14269,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -14476,7 +14372,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -15300,7 +15195,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -15656,7 +15550,7 @@
     "node_modules/postcss-modules-sync/node_modules/has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -15680,7 +15574,7 @@
     "node_modules/postcss-modules-sync/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -15689,7 +15583,7 @@
     "node_modules/postcss-modules-sync/node_modules/supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
       "dev": true,
       "dependencies": {
         "has-flag": "^1.0.0"
@@ -15957,18 +15851,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-selector-parser/node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-svgo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
@@ -16224,16 +16106,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -16262,13 +16134,6 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -16280,142 +16145,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
       "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
       "dev": true
-    },
-    "node_modules/pug": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pug-code-gen": "^3.0.2",
-        "pug-filters": "^4.0.0",
-        "pug-lexer": "^5.0.1",
-        "pug-linker": "^4.0.0",
-        "pug-load": "^3.0.0",
-        "pug-parser": "^6.0.0",
-        "pug-runtime": "^3.0.1",
-        "pug-strip-comments": "^2.0.0"
-      }
-    },
-    "node_modules/pug-attrs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "js-stringify": "^1.0.2",
-        "pug-runtime": "^3.0.0"
-      }
-    },
-    "node_modules/pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.2",
-        "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
-        "void-elements": "^3.1.0",
-        "with": "^7.0.0"
-      }
-    },
-    "node_modules/pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/pug-filters": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "constantinople": "^4.0.1",
-        "jstransformer": "1.0.0",
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0",
-        "resolve": "^1.15.1"
-      }
-    },
-    "node_modules/pug-lexer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "character-parser": "^2.2.0",
-        "is-expression": "^4.0.0",
-        "pug-error": "^2.0.0"
-      }
-    },
-    "node_modules/pug-linker": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "node_modules/pug-load": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "node_modules/pug-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pug-error": "^2.0.0",
-        "token-stream": "1.0.0"
-      }
-    },
-    "node_modules/pug-runtime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/pug-strip-comments": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pug-error": "^2.0.0"
-      }
-    },
-    "node_modules/pug-walk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -16443,9 +16172,9 @@
       }
     },
     "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
@@ -16612,24 +16341,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "node_modules/regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "dependencies": {
-        "jsesc": "~0.5.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -17031,23 +16742,61 @@
       }
     },
     "node_modules/rollup-plugin-vue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-5.0.0.tgz",
-      "integrity": "sha512-Yz1iq8PCzfsUnVg4Jv9pj2m88j+Y9/Mc8nai3QYCVl/3sMpLuHR+QV8Qf6+FaCvt2KaP6kJSyQvAnWdn1YFRTQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-4.7.2.tgz",
+      "integrity": "sha512-RuAK+YTL81/iccOWoadqQz2TXqOogivjbvtCuU6EfVP9/E5XIjuMNVsVWHkSelZQblI1z2b5tshWL7XoiOfABQ==",
       "dev": true,
       "dependencies": {
-        "@vue/component-compiler": "^4.0.0",
-        "@vue/component-compiler-utils": "^3.0.0",
+        "@vue/component-compiler": "^3.6",
+        "@vue/component-compiler-utils": "^2.1.0",
         "debug": "^4.1.1",
         "hash-sum": "^1.0.2",
         "magic-string": "^0.25.2",
         "querystring": "^0.2.0",
-        "rollup-pluginutils": "^2.4.1",
+        "rollup-pluginutils": "^2.0.1",
         "source-map": "0.7.3",
         "vue-runtime-helpers": "1.0.0"
       },
       "peerDependencies": {
         "vue-template-compiler": "*"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/@vue/component-compiler-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+      "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+      "dev": true,
+      "dependencies": {
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^5.0.0",
+        "prettier": "1.16.3",
+        "source-map": "~0.6.1",
+        "vue-template-es2015-compiler": "^1.9.0"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/@vue/component-compiler-utils/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/cssesc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+      "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/rollup-plugin-vue/node_modules/debug": {
@@ -17065,6 +16814,64 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/rollup-plugin-vue/node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-vue/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/postcss-selector-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+      "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^2.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/postcss/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-vue/node_modules/prettier": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/rollup-plugin-vue/node_modules/source-map": {
       "version": "0.7.3",
@@ -17163,24 +16970,6 @@
       "dependencies": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
-      }
-    },
-    "node_modules/sass": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.53.0.tgz",
-      "integrity": "sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/saxes": {
@@ -17519,9 +17308,9 @@
       "dev": true
     },
     "node_modules/sourcemap-codec": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "node_modules/spawn-sync": {
@@ -18101,13 +17890,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/token-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -18313,6 +18095,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -18527,21 +18315,15 @@
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
-      "dev": true
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.4.tgz",
+      "integrity": "sha512-8KGyyzFSj/FrKj1y7jyEpv8J4osgZx6Lk1lVzh1aP4BqsXZhATH1r0gdJNz00MMyBhK0/m2cNoPuOZ1NzeiUEw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.4",
+        "csstype": "^3.1.0"
+      }
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.0.3",
@@ -18679,25 +18461,89 @@
       "dev": true
     },
     "node_modules/vue-server-renderer": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
-      "integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.7.4.tgz",
+      "integrity": "sha512-fKyZ3X1Z2NalJOcIItYjjPF5NseIAiqFWDBluJD+fDQyYg4zyXB6fpQCA4j5JIfXdu/v1OJiyq8aVTu1Ofp75w==",
       "dev": true,
       "dependencies": {
-        "chalk": "^1.1.3",
-        "hash-sum": "^1.0.2",
-        "he": "^1.1.0",
+        "chalk": "^4.1.2",
+        "hash-sum": "^2.0.0",
+        "he": "^1.2.0",
         "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
-        "resolve": "^1.2.0",
-        "serialize-javascript": "^3.1.0",
+        "resolve": "^1.22.0",
+        "serialize-javascript": "^6.0.0",
         "source-map": "0.5.6"
       }
     },
+    "node_modules/vue-server-renderer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/vue-server-renderer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/vue-server-renderer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/vue-server-renderer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/vue-server-renderer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vue-server-renderer/node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "dev": true
+    },
     "node_modules/vue-server-renderer/node_modules/serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -18712,14 +18558,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/vue-server-renderer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/vue-template-compiler": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.4.tgz",
+      "integrity": "sha512-FgaeXI80FzhtDEsixq3WBrHLWpU2gzLb2DFusm62TrmCQyETsnUp0kTLpbExrTUw7g5YOnRf+xkh73nuEX+jGQ==",
       "dev": true,
       "dependencies": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "node_modules/vue-template-es2015-compiler": {
@@ -18727,6 +18585,17 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue/node_modules/@vue/compiler-sfc": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.4.tgz",
+      "integrity": "sha512-WCaF33mlKLSvHDKvOD6FzTa5CI2FlMTeJf3MxJsNP0KDgRoI6RdXhHo9dtvCqV4Sywf9Owm17wTLT1Ymu/WsOQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -18829,22 +18698,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
-    },
-    "node_modules/with": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
-        "assert-never": "^1.2.1",
-        "babel-walk": "3.0.0-canary-5"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -22054,20 +21907,76 @@
       "dev": true
     },
     "@vue/component-compiler": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler/-/component-compiler-4.2.4.tgz",
-      "integrity": "sha512-tFGw3h3+nxiqnyborwWQ+rUgKAwSFl0Sdg+BCZkWTyFfkEF5fqunTNoklEUDdtRQMmVqsajn1pOZdm0zh4Uicw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler/-/component-compiler-3.6.0.tgz",
+      "integrity": "sha512-NIA0vmOI4zbtJAn69iZls8IJ8VxmguswAuiUdu8TcR+YYTYzntfw290HUCSFjzAdRg+FUWZv8r+wc3TzJ/IjwA==",
       "dev": true,
       "requires": {
-        "@vue/component-compiler-utils": "^3.0.0",
+        "@vue/component-compiler-utils": "^2.1.0",
         "clean-css": "^4.1.11",
         "hash-sum": "^1.0.2",
-        "less": "^3.9.0",
         "postcss-modules-sync": "^1.0.0",
-        "pug": "^3.0.1",
-        "sass": "^1.18.0",
-        "source-map": "0.6.*",
-        "stylus": "^0.54.5"
+        "source-map": "0.6.*"
+      },
+      "dependencies": {
+        "@vue/component-compiler-utils": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+          "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+          "dev": true,
+          "requires": {
+            "consolidate": "^0.15.1",
+            "hash-sum": "^1.0.2",
+            "lru-cache": "^4.1.2",
+            "merge-source-map": "^1.1.0",
+            "postcss": "^7.0.14",
+            "postcss-selector-parser": "^5.0.0",
+            "prettier": "1.16.3",
+            "source-map": "~0.6.1",
+            "vue-template-es2015-compiler": "^1.9.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
+          }
+        },
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "prettier": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+          "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+          "dev": true
+        }
       }
     },
     "@vue/component-compiler-utils": {
@@ -22106,12 +22015,14 @@
       }
     },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.12.tgz",
-      "integrity": "sha512-457S/w+VuHnh4jw03ingrVAx8jMbxRz+jGGjoTeEFPZzv20GDzPUauQQqDy71EYw6BiNscC0RGOaLvAcS6BZ9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.3.0.tgz",
+      "integrity": "sha512-Xk2Xiyj2k5dFb8eYUKkcN9PzqZSppTlx7LaQWBbdA8tqh3jHr/KHX2/YLhNFc/xwDrgeLybqd+4ZCPJSGPIqeA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4"
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
       }
     },
     "abab": {
@@ -22316,13 +22227,6 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true,
-      "optional": true
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -22331,13 +22235,6 @@
       "requires": {
         "safer-buffer": "~2.1.0"
       }
-    },
-    "assert-never": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true,
-      "optional": true
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -22499,16 +22396,6 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
-      }
-    },
-    "babel-walk": {
-      "version": "3.0.0-canary-5",
-      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/types": "^7.9.6"
       }
     },
     "balanced-match": {
@@ -22811,16 +22698,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "character-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-regex": "^1.0.3"
-      }
-    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -22929,13 +22806,6 @@
           }
         }
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
-      "optional": true
     },
     "co": {
       "version": "4.6.0",
@@ -23085,17 +22955,6 @@
         "bluebird": "^3.1.1"
       }
     },
-    "constantinople": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.1"
-      }
-    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -23202,27 +23061,13 @@
       }
     },
     "css-selector-tokenizer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
       "dev": true,
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
-      },
-      "dependencies": {
-        "regexpu-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true,
-          "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
-          }
-        }
+        "cssesc": "^3.0.0",
+        "fastparse": "^1.1.2"
       }
     },
     "css-tree": {
@@ -23242,9 +23087,9 @@
       "dev": true
     },
     "cssesc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssnano": {
@@ -23333,6 +23178,12 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -23483,12 +23334,11 @@
         "esutils": "^2.0.2"
       }
     },
-    "doctypes": {
+    "dom-event-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.1.0.tgz",
+      "integrity": "sha512-jNCX+uNJ3v38BKvPbpki6j5ItVlnSqVV6vDWGS6rExzCMjsc39frLjm1n91o6YaKK6AZl0wLloItW6C6mr61BQ==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "1.4.1",
@@ -23594,7 +23444,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
       "dev": true
     },
     "end-of-stream": {
@@ -23611,16 +23461,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
       "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
       "dev": true
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -25515,7 +25355,7 @@
     "generic-names": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
-      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
+      "integrity": "sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==",
       "dev": true,
       "requires": {
         "loader-utils": "^0.2.16"
@@ -25899,20 +25739,6 @@
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
-    "image-size": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-      "dev": true,
-      "optional": true
-    },
-    "immutable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
-      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
-      "dev": true,
-      "optional": true
-    },
     "import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -26008,6 +25834,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA==",
       "dev": true
     },
     "inflight": {
@@ -26174,26 +26006,6 @@
       "dev": true,
       "optional": true
     },
-    "is-expression": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "acorn": "^7.1.1",
-        "object-assign": "^4.1.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -26268,13 +26080,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true,
-      "optional": true
     },
     "is-reference": {
       "version": "1.1.2",
@@ -29726,9 +29531,9 @@
       }
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "js-beautify": {
@@ -29749,13 +29554,6 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
-    },
-    "js-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-      "dev": true,
-      "optional": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -29878,7 +29676,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
       "dev": true
     },
     "jsprim": {
@@ -29891,17 +29689,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
-      }
-    },
-    "jstransformer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-promise": "^2.0.0",
-        "promise": "^7.0.1"
       }
     },
     "kind-of": {
@@ -29924,24 +29711,6 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
-    },
-    "less": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
-      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "clone": "^2.1.2",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "mime": "^1.4.1",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
-        "request": "^2.83.0",
-        "source-map": "~0.6.0"
-      }
     },
     "leven": {
       "version": "3.1.0",
@@ -30004,7 +29773,7 @@
     "loader-utils": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "integrity": "sha512-tiv66G0SmiOx+pLWMtGEkfSEejxvb6N6uRrQjfWJIT79W9GMpgKeCAmm9aVBKtd4WEgntciI8CsGqjpDoCWJug==",
       "dev": true,
       "requires": {
         "big.js": "^3.1.3",
@@ -30124,12 +29893,12 @@
       }
     },
     "magic-string": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -30296,13 +30065,6 @@
         }
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "optional": true
-    },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -30386,8 +30148,7 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -31004,7 +30765,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
       "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -31288,7 +31048,7 @@
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
           "dev": true
         },
         "postcss": {
@@ -31306,13 +31066,13 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
           "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
           "dev": true,
           "requires": {
             "has-flag": "^1.0.0"
@@ -31447,14 +31207,6 @@
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "cssesc": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-          "dev": true
-        }
       }
     },
     "postcss-svgo": {
@@ -31651,16 +31403,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -31683,13 +31425,6 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true
     },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true,
-      "optional": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -31701,142 +31436,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
       "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
       "dev": true
-    },
-    "pug": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "pug-code-gen": "^3.0.2",
-        "pug-filters": "^4.0.0",
-        "pug-lexer": "^5.0.1",
-        "pug-linker": "^4.0.0",
-        "pug-load": "^3.0.0",
-        "pug-parser": "^6.0.0",
-        "pug-runtime": "^3.0.1",
-        "pug-strip-comments": "^2.0.0"
-      }
-    },
-    "pug-attrs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "constantinople": "^4.0.1",
-        "js-stringify": "^1.0.2",
-        "pug-runtime": "^3.0.0"
-      }
-    },
-    "pug-code-gen": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "constantinople": "^4.0.1",
-        "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.2",
-        "pug-attrs": "^3.0.0",
-        "pug-error": "^2.0.0",
-        "pug-runtime": "^3.0.0",
-        "void-elements": "^3.1.0",
-        "with": "^7.0.0"
-      }
-    },
-    "pug-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
-      "dev": true,
-      "optional": true
-    },
-    "pug-filters": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "constantinople": "^4.0.1",
-        "jstransformer": "1.0.0",
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0",
-        "resolve": "^1.15.1"
-      }
-    },
-    "pug-lexer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "character-parser": "^2.2.0",
-        "is-expression": "^4.0.0",
-        "pug-error": "^2.0.0"
-      }
-    },
-    "pug-linker": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "pug-error": "^2.0.0",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "pug-load": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "pug-walk": "^2.0.0"
-      }
-    },
-    "pug-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "pug-error": "^2.0.0",
-        "token-stream": "1.0.0"
-      }
-    },
-    "pug-runtime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-      "dev": true,
-      "optional": true
-    },
-    "pug-strip-comments": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "pug-error": "^2.0.0"
-      }
-    },
-    "pug-walk": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
-      "dev": true,
-      "optional": true
     },
     "pump": {
       "version": "3.0.0",
@@ -31861,9 +31460,9 @@
       "dev": true
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
       "dev": true
     },
     "randombytes": {
@@ -31991,21 +31590,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -32327,22 +31911,53 @@
       }
     },
     "rollup-plugin-vue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-5.0.0.tgz",
-      "integrity": "sha512-Yz1iq8PCzfsUnVg4Jv9pj2m88j+Y9/Mc8nai3QYCVl/3sMpLuHR+QV8Qf6+FaCvt2KaP6kJSyQvAnWdn1YFRTQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-4.7.2.tgz",
+      "integrity": "sha512-RuAK+YTL81/iccOWoadqQz2TXqOogivjbvtCuU6EfVP9/E5XIjuMNVsVWHkSelZQblI1z2b5tshWL7XoiOfABQ==",
       "dev": true,
       "requires": {
-        "@vue/component-compiler": "^4.0.0",
-        "@vue/component-compiler-utils": "^3.0.0",
+        "@vue/component-compiler": "^3.6",
+        "@vue/component-compiler-utils": "^2.1.0",
         "debug": "^4.1.1",
         "hash-sum": "^1.0.2",
         "magic-string": "^0.25.2",
         "querystring": "^0.2.0",
-        "rollup-pluginutils": "^2.4.1",
+        "rollup-pluginutils": "^2.0.1",
         "source-map": "0.7.3",
         "vue-runtime-helpers": "1.0.0"
       },
       "dependencies": {
+        "@vue/component-compiler-utils": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz",
+          "integrity": "sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==",
+          "dev": true,
+          "requires": {
+            "consolidate": "^0.15.1",
+            "hash-sum": "^1.0.2",
+            "lru-cache": "^4.1.2",
+            "merge-source-map": "^1.1.0",
+            "postcss": "^7.0.14",
+            "postcss-selector-parser": "^5.0.0",
+            "prettier": "1.16.3",
+            "source-map": "~0.6.1",
+            "vue-template-es2015-compiler": "^1.9.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -32356,6 +31971,47 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.39",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+          "dev": true,
+          "requires": {
+            "picocolors": "^0.2.1",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "prettier": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+          "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
           "dev": true
         },
         "source-map": {
@@ -32434,18 +32090,6 @@
             "normalize-path": "^2.1.1"
           }
         }
-      }
-    },
-    "sass": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.53.0.tgz",
-      "integrity": "sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "saxes": {
@@ -32719,9 +32363,9 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-sync": {
@@ -33179,13 +32823,6 @@
         }
       }
     },
-    "token-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
-      "dev": true,
-      "optional": true
-    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -33349,6 +32986,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -33517,18 +33160,28 @@
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
-    "void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "dev": true,
-      "optional": true
-    },
     "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
-      "dev": true
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.4.tgz",
+      "integrity": "sha512-8KGyyzFSj/FrKj1y7jyEpv8J4osgZx6Lk1lVzh1aP4BqsXZhATH1r0gdJNz00MMyBhK0/m2cNoPuOZ1NzeiUEw==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-sfc": "2.7.4",
+        "csstype": "^3.1.0"
+      },
+      "dependencies": {
+        "@vue/compiler-sfc": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.4.tgz",
+          "integrity": "sha512-WCaF33mlKLSvHDKvOD6FzTa5CI2FlMTeJf3MxJsNP0KDgRoI6RdXhHo9dtvCqV4Sywf9Owm17wTLT1Ymu/WsOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.18.4",
+            "postcss": "^8.4.14",
+            "source-map": "^0.6.1"
+          }
+        }
+      }
     },
     "vue-eslint-parser": {
       "version": "9.0.3",
@@ -33625,25 +33278,71 @@
       "dev": true
     },
     "vue-server-renderer": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
-      "integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.7.4.tgz",
+      "integrity": "sha512-fKyZ3X1Z2NalJOcIItYjjPF5NseIAiqFWDBluJD+fDQyYg4zyXB6fpQCA4j5JIfXdu/v1OJiyq8aVTu1Ofp75w==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "hash-sum": "^1.0.2",
-        "he": "^1.1.0",
+        "chalk": "^4.1.2",
+        "hash-sum": "^2.0.0",
+        "he": "^1.2.0",
         "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
-        "resolve": "^1.2.0",
-        "serialize-javascript": "^3.1.0",
+        "resolve": "^1.22.0",
+        "serialize-javascript": "^6.0.0",
         "source-map": "0.5.6"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "hash-sum": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+          "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+          "dev": true
+        },
         "serialize-javascript": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
           "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
@@ -33654,17 +33353,26 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.4.tgz",
+      "integrity": "sha512-FgaeXI80FzhtDEsixq3WBrHLWpU2gzLb2DFusm62TrmCQyETsnUp0kTLpbExrTUw7g5YOnRf+xkh73nuEX+jGQ==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "vue-template-es2015-compiler": {
@@ -33759,19 +33467,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
-    },
-    "with": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
-        "assert-never": "^1.2.1",
-        "babel-walk": "3.0.0-canary-5"
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-1.6.1",
+  "version": "1.6.2-reedsy-1.6.2",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "keywords": [
     "vue",
@@ -38,11 +38,12 @@
     "@babel/node": "^7.4.5",
     "@babel/plugin-external-helpers": "^7.2.0",
     "@babel/plugin-transform-modules-commonjs": "^7.4.4",
+    "@babel/plugin-transform-runtime": "^7.18.6",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-stage-2": "^7.0.0",
     "@babel/register": "^7.4.4",
     "@babel/runtime": "^7.18.6",
-    "@vue/test-utils": "^1.0.0-beta.12",
+    "@vue/test-utils": "^1.3.0",
     "autoprefixer": "^10.4.7",
     "babel-jest": "^24.8.0",
     "chalk": "^1.1.3",
@@ -73,16 +74,13 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-serve": "^1.0.1",
     "rollup-plugin-terser": "^5.0.0",
-    "rollup-plugin-vue": "^5.0.0",
+    "rollup-plugin-vue": "^4.7.2",
     "semver": "^5.3.0",
     "shelljs": "^0.8.3",
     "stylus": "^0.54.5",
-    "vue": "^2.6.10",
-    "vue-jest": "^4.0.0-beta.2",
-    "vue-server-renderer": "^2.6.10",
-    "vue-template-compiler": "^2.6.10"
-  },
-  "dependencies": {
-    "@babel/plugin-transform-runtime": "^7.18.6"
+    "vue": "^2.7.4",
+    "vue-jest": "^4.0.1",
+    "vue-server-renderer": "^2.7.4",
+    "vue-template-compiler": "^2.7.4"
   }
 }

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -572,7 +572,10 @@ export default {
       if (emitEvent) {
         this.$emit('closed');
         const input = this.$refs.input;
-        if (input && input.$el.querySelector) input.$el.querySelector('input').focus();
+        if (!input) return;
+        const inputEl = input.$el.querySelector('input');
+        if (!inputEl) return;
+        inputEl.focus();
       }
 
       document.removeEventListener('click', this.clickOutside, false);

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -395,7 +395,7 @@ export default {
      * @param {Date} date
      */
     highlightOnMouseover (date) {
-      if (this.isDisabledDate(date)) return;
+      if (this.isDisabledDate(date) || !this.highlightDate) return;
       this.highlightDate(date);
     },
     /**

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -1,12 +1,12 @@
 import DateInput from '@/components/DateInput.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('DateInput', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(DateInput, {
+    wrapper = shallowMount(DateInput, {
       propsData: {
         selectedDate: new Date(2018, 2, 24),
         format: 'dd MMM yyyy',
@@ -19,8 +19,8 @@ describe('DateInput', () => {
     expect(wrapper.findAll('input')).toHaveLength(1);
   });
 
-  it('nulls date', () => {
-    wrapper.setProps({
+  it('nulls date', async () => {
+    await wrapper.setProps({
       selectedDate: null,
     });
     expect(wrapper.vm.formattedValue).toBeNull();
@@ -32,8 +32,8 @@ describe('DateInput', () => {
     expect(wrapper.find('input').element.value).toEqual('24 Mar 2018');
   });
 
-  it('delegates date formatting', () => {
-    wrapper.setProps({
+  it('delegates date formatting', async () => {
+    await wrapper.setProps({
       selectedDate: new Date(2016, 1, 15),
       format: () => '2016/1/15',
     });
@@ -46,15 +46,15 @@ describe('DateInput', () => {
     expect(wrapper.emitted().showCalendar).toBeTruthy();
   });
 
-  it('adds bootstrap classes', () => {
-    wrapper.setProps({
+  it('adds bootstrap classes', async () => {
+    await wrapper.setProps({
       bootstrapStyling: true,
     });
     expect(wrapper.find('input').element.classList).toContain('form-control');
   });
 
-  it('appends bootstrap classes', () => {
-    wrapper.setProps({
+  it('appends bootstrap classes', async () => {
+    await wrapper.setProps({
       inputClass: 'someClass',
       bootstrapStyling: true,
     });
@@ -62,8 +62,8 @@ describe('DateInput', () => {
     expect(wrapper.find('input').element.classList).toContain('someClass');
   });
 
-  it('can be disabled', () => {
-    wrapper.setProps({
+  it('can be disabled', async () => {
+    await wrapper.setProps({
       disabled: true,
     });
     expect(wrapper.find('input').attributes().disabled).toBeDefined();

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -1,12 +1,12 @@
 import DateInput from '@/components/DateInput.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('DateInput', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = shallow(DateInput, {
+    wrapper = shallowMount(DateInput, {
       propsData: {
         format: 'dd MMM yyyy',
         translation: en,
@@ -15,14 +15,14 @@ describe('DateInput', () => {
     });
   });
 
-  it('does not format the date when typed', () => {
+  it('does not format the date when typed', async () => {
     const dateString = '2018-04-24';
     wrapper.vm.input.value = dateString;
     expect(wrapper.vm.input.value).toEqual(dateString);
-    wrapper.setData({
+    await wrapper.setData({
       typedDate: dateString,
     });
-    wrapper.setProps({
+    await wrapper.setProps({
       selectedDate: new Date(dateString),
     });
     expect(wrapper.vm.typedDate).toEqual(dateString);
@@ -44,15 +44,15 @@ describe('DateInput', () => {
     expect(blurSpy).toBeCalled();
   });
 
-  it('clears a typed date if it does not parse', () => {
+  it('clears a typed date if it does not parse', async () => {
     const input = wrapper.find('input');
-    wrapper.setData({ typedDate: 'not a date' });
+    await wrapper.setData({ typedDate: 'not a date' });
     input.trigger('blur');
     expect(wrapper.emitted().clearDate).toBeDefined();
   });
 
   it('doesn\'t emit the date if typeable=false', () => {
-    const wrapper = shallow(DateInput, {
+    const wrapper = shallowMount(DateInput, {
       propsData: {
         format: 'dd MMM yyyy',
         translation: en,

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -1,6 +1,6 @@
 import Datepicker from '@/components/Datepicker.vue';
 import DateInput from '@/components/DateInput.vue';
-import { shallow, mount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import { makeDateUtils } from '@/utils/DateUtils';
 import { en } from '@/locale';
 
@@ -27,7 +27,7 @@ describe('Datepicker mounted', () => {
   let date;
   beforeEach(() => {
     date = new Date(2016, 1, 15);
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
         value: date,
@@ -55,7 +55,7 @@ describe('Datepicker mounted', () => {
 
   it('sets the date', () => {
     const date = new Date(2016, 9, 9);
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
       },
@@ -67,7 +67,7 @@ describe('Datepicker mounted', () => {
   it('changes the page date when selecting a date from a different month', () => {
     const initialDate = new Date(Date.UTC(2016, 8, 9));
     const date = new Date(Date.UTC(2016, 9, 9));
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
         openDate: initialDate,
@@ -81,7 +81,7 @@ describe('Datepicker mounted', () => {
   it('does not change the page when selecting a date in the same month', () => {
     const initialDate = new Date(Date.UTC(2016, 8, 9));
     const date = new Date(Date.UTC(2016, 8, 11));
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
         openDate: initialDate,
@@ -95,7 +95,7 @@ describe('Datepicker mounted', () => {
   it('does not change the page when selecting a date in the next month for a side-by-side layout', () => {
     const initialDate = new Date(Date.UTC(2016, 8, 9));
     const date = new Date(Date.UTC(2016, 9, 11));
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
         openDate: initialDate,
@@ -110,7 +110,7 @@ describe('Datepicker mounted', () => {
   it('changes the page when selecting a date in a different month for a side-by-side layout', () => {
     const initialDate = new Date(Date.UTC(2016, 8, 9));
     const date = new Date(Date.UTC(2016, 7, 11));
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy-MM-dd',
         openDate: initialDate,
@@ -124,7 +124,7 @@ describe('Datepicker mounted', () => {
 
   it('clears the date', () => {
     const date = new Date(2016, 9, 9);
-    const wrapper = shallow(Datepicker);
+    const wrapper = shallowMount(Datepicker);
     wrapper.vm.setDate(date.getTime());
     wrapper.vm.clearDate();
     expect(wrapper.vm.selectedDate).toEqual(null);
@@ -195,7 +195,7 @@ describe('Datepicker mounted', () => {
   });
 
   it('resets the default page date', () => {
-    const wrapper = shallow(Datepicker);
+    const wrapper = shallowMount(Datepicker);
     const today = new Date();
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());
     expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth());
@@ -207,7 +207,7 @@ describe('Datepicker mounted', () => {
   });
 
   it('does not set the default page date if a date is selected', () => {
-    const wrapper = shallow(Datepicker);
+    const wrapper = shallowMount(Datepicker);
     const today = new Date();
     const pastDate = new Date(2018, 3, 20);
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());
@@ -221,14 +221,14 @@ describe('Datepicker mounted', () => {
   });
 
   it('sets the date on typedDate event', () => {
-    const wrapper = shallow(Datepicker);
+    const wrapper = shallowMount(Datepicker);
     const today = new Date();
     wrapper.vm.setTypedDate(today);
     expect(wrapper.vm.selectedDate).toEqual(today);
   });
 
   it('watches value', done => {
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         value: '2018-01-01',
       },
@@ -242,7 +242,7 @@ describe('Datepicker mounted', () => {
   });
 
   it('watches openDate', done => {
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         openDate: new Date(2018, 0, 1),
       },
@@ -256,7 +256,7 @@ describe('Datepicker mounted', () => {
   });
 
   it('watches initialView', done => {
-    const wrapper = shallow(Datepicker, {
+    const wrapper = shallowMount(Datepicker, {
       propsData: {
         initialView: 'day',
       },
@@ -285,7 +285,7 @@ describe('Datepicker mounted', () => {
 describe('Datepicker.vue set by string', () => {
   let wrapper;
   it('can parse a string date', () => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy MM dd',
         value: '2016-02-20',
@@ -298,7 +298,7 @@ describe('Datepicker.vue set by string', () => {
   });
 
   it('should nullify malformed value', () => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         value: 'today',
       },
@@ -310,7 +310,7 @@ describe('Datepicker.vue set by string', () => {
 describe('Datepicker.vue set by timestamp', () => {
   let wrapper;
   it('can parse unix timestamp', () => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         format: 'yyyy MM dd',
         value: new Date(Date.UTC(2018, 0, 29)).getTime(),
@@ -354,7 +354,7 @@ describe('Datepicker.vue using UTC', () => {
 describe('Datepicker with initial-view', () => {
   let wrapper;
   it('should open in Day view', async () => {
-    wrapper = shallow(Datepicker);
+    wrapper = shallowMount(Datepicker);
     await wrapper.vm.showCalendar();
     expect(wrapper.vm.computedInitialView).toEqual('day');
     expect(wrapper.vm.showDayView).toEqual(true);
@@ -363,7 +363,7 @@ describe('Datepicker with initial-view', () => {
   });
 
   it('should open in Month view', async () => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         initialView: 'month',
       },
@@ -376,7 +376,7 @@ describe('Datepicker with initial-view', () => {
   });
 
   it('should open in Year view', async () => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         initialView: 'year',
       },
@@ -392,7 +392,7 @@ describe('Datepicker with initial-view', () => {
 describe('Focus after opening the datepicker', () => {
   describe('Days', () => {
     it('should focus on the current day', async () => {
-      const wrapper = mount(Datepicker, { attachToDocument: true });
+      const wrapper = mount(Datepicker, { attachTo: document.body });
       const today = new Date();
       await wrapper.vm.showCalendar();
       expect(document.activeElement.textContent.trim()).toEqual(today.getDate().toString());
@@ -405,7 +405,7 @@ describe('Focus after opening the datepicker', () => {
         propsData: {
           minimumView: 'month',
         },
-        attachToDocument: true,
+        attachTo: document.body,
       });
       const today = new Date();
       await wrapper.vm.showCalendar();
@@ -419,7 +419,7 @@ describe('Focus after opening the datepicker', () => {
         propsData: {
           minimumView: 'year',
         },
-        attachToDocument: true,
+        attachTo: document.body,
       });
       const today = new Date();
       await wrapper.vm.showCalendar();
@@ -431,7 +431,7 @@ describe('Focus after opening the datepicker', () => {
 
 describe('Focus after closing the datepicker', () => {
   it('should focus on the input', async () => {
-    const wrapper = mount(Datepicker, { attachToDocument: true });
+    const wrapper = mount(Datepicker, { attachTo: document.body });
     await wrapper.vm.showCalendar();
     wrapper.vm.close(true);
     const input = wrapper.vm.$refs.input.$el.querySelector('input');

--- a/test/unit/specs/Datepicker/inline.spec.js
+++ b/test/unit/specs/Datepicker/inline.spec.js
@@ -1,10 +1,10 @@
 import Datepicker from '@/components/Datepicker.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 
 describe('Datepicker.vue inline', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         inline: true,
       },

--- a/test/unit/specs/Datepicker/openDate.spec.js
+++ b/test/unit/specs/Datepicker/openDate.spec.js
@@ -1,11 +1,11 @@
 import Datepicker from '@/components/Datepicker.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 
 describe('Datepicker with open date', () => {
   const openDate = new Date(2016, 9, 12);
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(Datepicker, {
+    wrapper = shallowMount(Datepicker, {
       propsData: {
         openDate,
       },
@@ -34,7 +34,7 @@ describe('Datepicker with open date', () => {
   });
 
   it('should show today\'s date if no open date is set', () => {
-    wrapper = shallow(Datepicker);
+    wrapper = shallowMount(Datepicker);
     const today = new Date();
     expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth());
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());

--- a/test/unit/specs/DaysGrid/daysGrid.spec.js
+++ b/test/unit/specs/DaysGrid/daysGrid.spec.js
@@ -1,5 +1,5 @@
 import DaysGrid from '@/components/DaysGrid.vue';
-import { mount, shallow } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 import { makeDateUtils } from '@/utils/DateUtils';
 
@@ -21,7 +21,7 @@ describe('DaysGrid: DOM', () => {
         useUtc: true,
         days,
       },
-      attachToDocument: true,
+      attachTo: document.body,
     });
   });
 
@@ -109,8 +109,8 @@ describe('DaysGrid: DOM', () => {
     });
   });
 
-  it('displays the days of the week in the right order when Monday is the first day', () => {
-    wrapper.setProps({ mondayFirst: true });
+  it('displays the days of the week in the right order when Monday is the first day', async () => {
+    await wrapper.setProps({ mondayFirst: true });
     const days = [ 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' ];
     const dayHeaders = wrapper.findAll('.cell.day-header');
     days.forEach((day, index) => {

--- a/test/unit/specs/DaysGrid/mondayFirst.spec.js
+++ b/test/unit/specs/DaysGrid/mondayFirst.spec.js
@@ -1,5 +1,5 @@
 import DaysGrid from '@/components/DaysGrid.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 import { makeDateUtils } from '@/utils/DateUtils';
 
@@ -8,7 +8,7 @@ const constructedDateUtils = makeDateUtils(true);
 describe('DaysGrid: Datepicker with monday as first day of week', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(DaysGrid, {
+    wrapper = shallowMount(DaysGrid, {
       propsData: {
         mondayFirst: true,
         translation: en,
@@ -27,15 +27,15 @@ describe('DaysGrid: Datepicker with monday as first day of week', () => {
     expect(wrapper.vm.daysOfWeek[6]).toEqual('Sun');
   });
 
-  it('should have 6 blankDays when month starts from Sunday', () => {
-    wrapper.setProps({
+  it('should have 6 blankDays when month starts from Sunday', async () => {
+    await wrapper.setProps({
       startDate: new Date(Date.UTC(2018, 3, 1)),
     });
     expect(wrapper.vm.blankDays).toEqual(6);
   });
 
-  it('should have no blankDays when month starts from Monday', () => {
-    wrapper.setProps({
+  it('should have no blankDays when month starts from Monday', async () => {
+    await wrapper.setProps({
       startDate: new Date(Date.UTC(2018, 9, 1)),
     });
     expect(wrapper.vm.blankDays).toEqual(0);

--- a/test/unit/specs/PickerDay/changeFocus.spec.js
+++ b/test/unit/specs/PickerDay/changeFocus.spec.js
@@ -14,7 +14,7 @@ describe('PickerDay: changing focus', () => {
         focusedDate: new Date(Date.UTC(2018, 1, 15)).getTime(),
         useUtc: true,
       },
-      attachToDocument: true,
+      attachTo: document.body,
     });
   });
 
@@ -28,14 +28,14 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 1, 16)).getTime() ] ]);
     });
 
-    it('changes to the next month if the current focused date is the last day of the month', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 28)).getTime() });
+    it('changes to the next month if the current focused date is the last day of the month', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 28)).getTime() });
       wrapper.vm.focusNextDay();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 2, 1)).getTime() ] ]);
     });
 
-    it('displays the next month if the current focused date is the last day of the month', () => {
-      wrapper.setProps({
+    it('displays the next month if the current focused date is the last day of the month', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 1, 28)).getTime(),
       });
@@ -43,8 +43,8 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('changedMonth')).toEqual([ [ new Date(Date.UTC(2018, 2, 1)) ] ]);
     });
 
-    it('does not display the next month if it is side by side and the current focused date is the last day of the first visible month', () => {
-      wrapper.setProps({
+    it('does not display the next month if it is side by side and the current focused date is the last day of the first visible month', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 1, 28)).getTime(),
         sideBySide: true,
@@ -57,16 +57,14 @@ describe('PickerDay: changing focus', () => {
     it('focuses on the new focused date after it changes', async () => {
       wrapper.vm.focusNextDay();
       // fake the .sync prop update
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2018, 1, 16)).getTime(),
       });
-      await wrapper.vm.$nextTick();
       expect(document.activeElement.textContent.trim()).toEqual('16');
       wrapper.vm.focusNextDay();
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2018, 1, 17)).getTime(),
       });
-      await wrapper.vm.$nextTick();
       expect(document.activeElement.textContent.trim()).toEqual('17');
     });
   });
@@ -77,14 +75,14 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 1, 14)).getTime() ] ]);
     });
 
-    it('changes to the previous month if the current focused date is the first day of the month', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 1)).getTime() });
+    it('changes to the previous month if the current focused date is the first day of the month', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 1)).getTime() });
       wrapper.vm.focusPreviousDay();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 0, 31)).getTime() ] ]);
     });
 
-    it('displays the previous month if the current focused date is the first day of the month', () => {
-      wrapper.setProps({
+    it('displays the previous month if the current focused date is the first day of the month', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 2, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 2, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 2, 1)).getTime(),
@@ -93,8 +91,8 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('changedMonth')).toEqual([ [ new Date(Date.UTC(2018, 1, 1)) ] ]);
     });
 
-    it('does not display the previous month if it is side by side and the current focused date is the first day of the first visible month', () => {
-      wrapper.setProps({
+    it('does not display the previous month if it is side by side and the current focused date is the first day of the first visible month', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 2, 1)).getTime(),
         sideBySide: true,
@@ -111,14 +109,14 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 1, 22)).getTime() ] ]);
     });
 
-    it('changes to the next month if the current focused date is the last week of the month', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 26)).getTime() });
+    it('changes to the next month if the current focused date is the last week of the month', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 26)).getTime() });
       wrapper.vm.focusNextWeek();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 2, 5)).getTime() ] ]);
     });
 
-    it('displays the next month if the current focused date is the last week of the month', () => {
-      wrapper.setProps({
+    it('displays the next month if the current focused date is the last week of the month', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 1, 26)).getTime(),
       });
@@ -126,8 +124,8 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('changedMonth')).toEqual([ [ new Date(Date.UTC(2018, 2, 1)) ] ]);
     });
 
-    it('does not display the next month if it is side by side and the current focused date is the last week of the first visible month', () => {
-      wrapper.setProps({
+    it('does not display the next month if it is side by side and the current focused date is the last week of the first visible month', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 1, 26)).getTime(),
         sideBySide: true,
@@ -144,14 +142,14 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 1, 8)).getTime() ] ]);
     });
 
-    it('changes to the previous month if the current focused date is the first week of the month', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 6)).getTime() });
+    it('changes to the previous month if the current focused date is the first week of the month', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 6)).getTime() });
       wrapper.vm.focusPreviousWeek();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 0, 30)).getTime() ] ]);
     });
 
-    it('displays the previous month if the current focused date is the first week of the month', () => {
-      wrapper.setProps({
+    it('displays the previous month if the current focused date is the first week of the month', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 2, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 2, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 2, 5)).getTime(),
@@ -160,8 +158,8 @@ describe('PickerDay: changing focus', () => {
       expect(wrapper.emitted('changedMonth')).toEqual([ [ new Date(Date.UTC(2018, 1, 1)) ] ]);
     });
 
-    it('does not display the previous month if it is side by side and the current focused date is the first week of the second visible month', () => {
-      wrapper.setProps({
+    it('does not display the previous month if it is side by side and the current focused date is the first week of the second visible month', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 1, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 2, 5)).getTime(),
@@ -175,7 +173,7 @@ describe('PickerDay: changing focus', () => {
 
   it('focuses on the focused day when showing the day view', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('15');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: true,
       showDayView: true,
     });
@@ -185,11 +183,10 @@ describe('PickerDay: changing focus', () => {
 
   it('does not focus on the focused day when showing the day view before initializing', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('15');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: false,
       showDayView: true,
     });
-    await wrapper.vm.$nextTick();
     expect(document.activeElement.textContent.trim()).not.toEqual('15');
   });
 });

--- a/test/unit/specs/PickerDay/changeMonths.spec.js
+++ b/test/unit/specs/PickerDay/changeMonths.spec.js
@@ -1,11 +1,11 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerDay: changing months', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         translation: en,
         allowedToShowView: () => true,

--- a/test/unit/specs/PickerDay/disabledDates.spec.js
+++ b/test/unit/specs/PickerDay/disabledDates.spec.js
@@ -1,11 +1,11 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerDay: disabled', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         showMonthCalendar: () => {},
@@ -39,8 +39,8 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isNextMonthDisabled()).toBeTruthy();
   });
 
-  it('should detect disabled dates', () => {
-    wrapper.setProps({
+  it('should detect disabled dates', async () => {
+    await wrapper.setProps({
       disabledDates: {
         ranges: [ {
           from: new Date(2005, 6, 5),
@@ -55,8 +55,8 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2026, 9, 2))).toEqual(true);
   });
 
-  it('can accept an array of disabled dates', () => {
-    wrapper.setProps({
+  it('can accept an array of disabled dates', async () => {
+    await wrapper.setProps({
       disabledDates: {
         dates: [
           new Date(2016, 9, 2),
@@ -69,8 +69,8 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 3))).toEqual(false);
   });
 
-  it('can accept an array of disabled days of the week', () => {
-    wrapper.setProps({
+  it('can accept an array of disabled days of the week', async () => {
+    await wrapper.setProps({
       disabledDates: {
         days: [ 6, 0 ],
       },
@@ -79,8 +79,8 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 3))).toEqual(false);
   });
 
-  it('can accept an array of disabled days of the month', () => {
-    wrapper.setProps({
+  it('can accept an array of disabled days of the month', async () => {
+    await wrapper.setProps({
       disabledDates: {
         daysOfMonth: [ 29, 30, 31 ],
       },
@@ -91,8 +91,8 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 11))).toEqual(false);
   });
 
-  it('can accept a customPredictor to check if the date is disabled', () => {
-    wrapper.setProps({
+  it('can accept a customPredictor to check if the date is disabled', async () => {
+    await wrapper.setProps({
       disabledDates: {
         customPredictor (date) {
           if (date.getDate() % 4 === 0) {

--- a/test/unit/specs/PickerDay/highlightedDates.spec.js
+++ b/test/unit/specs/PickerDay/highlightedDates.spec.js
@@ -1,11 +1,11 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerDay highlight date', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -30,8 +30,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightedDate(new Date(Date.UTC(2016, 12, 5)))).toEqual(false);
   });
 
-  it('should highlight a disabled date when explicitly configured to', () => {
-    wrapper.setProps({
+  it('should highlight a disabled date when explicitly configured to', async () => {
+    await wrapper.setProps({
       highlighted: {
         to: new Date(Date.UTC(2016, 12, 8)),
         from: new Date(Date.UTC(2016, 12, 4)),
@@ -57,8 +57,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightedDate(new Date(Date.UTC(2016, 12, 3)))).toEqual(false);
   });
 
-  it('can accept an array of highlighted dates', () => {
-    wrapper.setProps({
+  it('can accept an array of highlighted dates', async () => {
+    await wrapper.setProps({
       highlighted: {
         dates: [
           new Date(Date.UTC(2016, 9, 2)),
@@ -71,8 +71,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightedDate(new Date(Date.UTC(2016, 9, 3)))).toEqual(false);
   });
 
-  it('can accept an array of highlighted days of the week', () => {
-    wrapper.setProps({
+  it('can accept an array of highlighted days of the week', async () => {
+    await wrapper.setProps({
       highlighted: {
         days: [ 6, 0 ],
       },
@@ -81,8 +81,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightedDate(new Date(Date.UTC(2016, 9, 3)))).toEqual(false);
   });
 
-  it('can accept an array of highlighted days of the month', () => {
-    wrapper.setProps({
+  it('can accept an array of highlighted days of the month', async () => {
+    await wrapper.setProps({
       highlighted: {
         daysOfMonth: [ 1, 10, 31 ],
       },
@@ -95,8 +95,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightedDate(new Date(Date.UTC(2016, 7, 20)))).toEqual(false);
   });
 
-  it('can accept a customPredictor to check if the date is highlighted', () => {
-    wrapper.setProps({
+  it('can accept a customPredictor to check if the date is highlighted', async () => {
+    await wrapper.setProps({
       highlighted: {
         customPredictor (date) {
           if (date.getDate() % 5 === 0) {
@@ -123,8 +123,8 @@ describe('PickerDay highlight date', () => {
     expect(wrapper.vm.isHighlightEnd(new Date(Date.UTC(2016, 12, 7)))).toEqual(false);
   });
 
-  it('should execute highlight props if date is not disabled', () => {
-    wrapper.setProps({
+  it('should execute highlight props if date is not disabled', async () => {
+    await wrapper.setProps({
       highlightDate: jest.fn(),
     });
 
@@ -133,8 +133,8 @@ describe('PickerDay highlight date', () => {
     wrapper.vm.highlightDate.mockClear();
   });
 
-  it('should NOT execute highlight props if date is disabled', () => {
-    wrapper.setProps({
+  it('should NOT execute highlight props if date is disabled', async () => {
+    await wrapper.setProps({
       highlightDate: jest.fn(),
     });
 

--- a/test/unit/specs/PickerDay/initialDom.spec.js
+++ b/test/unit/specs/PickerDay/initialDom.spec.js
@@ -1,11 +1,11 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerDay: DOM', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,

--- a/test/unit/specs/PickerDay/pickerDay.spec.js
+++ b/test/unit/specs/PickerDay/pickerDay.spec.js
@@ -1,5 +1,5 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { mount, shallow } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 import DaysGrid from '@/components/DaysGrid';
 import PickerFooter from '@/components/PickerFooter';
@@ -7,7 +7,7 @@ import PickerFooter from '@/components/PickerFooter';
 describe('PickerDay: DOM', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -17,9 +17,9 @@ describe('PickerDay: DOM', () => {
     });
   });
 
-  it('knows the selected date', () => {
+  it('knows the selected date', async () => {
     const newDate = new Date(2016, 9, 15);
-    wrapper.setProps({
+    await wrapper.setProps({
       selectedDate: newDate,
     });
     expect(wrapper.vm.isSelectedDate(newDate)).toEqual(true);
@@ -31,8 +31,8 @@ describe('PickerDay: DOM', () => {
     expect(wrapper.emitted().selectDate).toBeTruthy();
   });
 
-  it('calls the function in highlightDate when hovering on a day cell', () => {
-    wrapper.setProps({
+  it('calls the function in highlightDate when hovering on a day cell', async () => {
+    await wrapper.setProps({
       highlightDate: jest.fn(),
     });
     const daysGrids = wrapper.findAll(DaysGrid);
@@ -42,9 +42,9 @@ describe('PickerDay: DOM', () => {
     expect(wrapper.props().highlightDate).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call the function in highlightDate when hovering on a disabled day cell', () => {
+  it('does not call the function in highlightDate when hovering on a disabled day cell', async () => {
     const date = new Date(2021, 8, 30);
-    wrapper.setProps({
+    await wrapper.setProps({
       highlightDate: jest.fn(),
       disabledDates: {
         dates: [ date ],
@@ -57,8 +57,8 @@ describe('PickerDay: DOM', () => {
     expect(wrapper.props().highlightDate).toHaveBeenCalledTimes(0);
   });
 
-  it('calls the function in highlightDate when hovering on a day cell in the next month of a side by side calendar', () => {
-    wrapper.setProps({
+  it('calls the function in highlightDate when hovering on a day cell in the next month of a side by side calendar', async () => {
+    await wrapper.setProps({
       highlightDate: jest.fn(),
       sideBySide: true,
     });
@@ -79,20 +79,20 @@ describe('PickerDay: DOM', () => {
     expect(wrapper.emitted().showMonthCalendar).toBeTruthy();
   });
 
-  it('displays the footer if the showFooter prop is true', () => {
-    wrapper.setProps({ showFooter: true });
+  it('displays the footer if the showFooter prop is true', async () => {
+    await wrapper.setProps({ showFooter: true });
     const footer = wrapper.find(PickerFooter);
     expect(footer.exists()).toBe(true);
   });
 
-  it('does not display the footer if the showFooter prop is false', () => {
-    wrapper.setProps({ showFooter: false });
+  it('does not display the footer if the showFooter prop is false', async () => {
+    await wrapper.setProps({ showFooter: false });
     const footer = wrapper.find(PickerFooter);
     expect(footer.exists()).toBe(false);
   });
 
   it('displays a custom footer from a slot and hides the default footer', () => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,

--- a/test/unit/specs/PickerDay/setToday.spec.js
+++ b/test/unit/specs/PickerDay/setToday.spec.js
@@ -1,11 +1,11 @@
 import PickerDay from '@/components/PickerDay.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerDay: setToday', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerDay, {
+    wrapper = shallowMount(PickerDay, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,

--- a/test/unit/specs/PickerMonth/changeFocus.spec.js
+++ b/test/unit/specs/PickerMonth/changeFocus.spec.js
@@ -14,7 +14,7 @@ describe('PickerMonth: changing focus', () => {
         focusedDate: new Date(Date.UTC(2018, 1, 15)).getTime(),
         useUtc: true,
       },
-      attachToDocument: true,
+      attachTo: document.body,
     });
   });
 
@@ -28,14 +28,14 @@ describe('PickerMonth: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 2, 15)).getTime() ] ]);
     });
 
-    it('changes to the next year if the current focused date is the last month of the year', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 11, 28)).getTime() });
+    it('changes to the next year if the current focused date is the last month of the year', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 11, 28)).getTime() });
       wrapper.vm.focusNextMonth();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2019, 0, 28)).getTime() ] ]);
     });
 
-    it('displays the next year if the current focused date is the last month of the year', () => {
-      wrapper.setProps({
+    it('displays the next year if the current focused date is the last month of the year', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 1, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 11, 28)).getTime(),
@@ -46,14 +46,14 @@ describe('PickerMonth: changing focus', () => {
 
     it('focuses on the new focused month after it changes', async () => {
       // fake the .sync prop update
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2018, 2, 15)).getTime(),
       });
       wrapper.vm.focusNextMonth();
       await wrapper.vm.$nextTick();
       expect(document.activeElement.textContent.trim()).toEqual('March');
       wrapper.vm.focusNextMonth();
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2018, 3, 15)).getTime(),
       });
       await wrapper.vm.$nextTick();
@@ -62,19 +62,19 @@ describe('PickerMonth: changing focus', () => {
   });
 
   describe('focusPreviousMonth', () => {
-    it('changes the focused date to the previous month', () => {
-      wrapper.vm.focusPreviousMonth();
+    it('changes the focused date to the previous month', async () => {
+      await wrapper.vm.focusPreviousMonth();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 0, 15)).getTime() ] ]);
     });
 
-    it('changes to the previous year if the current focused date is the first month of the year', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 0, 1)).getTime() });
+    it('changes to the previous year if the current focused date is the first month of the year', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 0, 1)).getTime() });
       wrapper.vm.focusPreviousMonth();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2017, 11, 1)).getTime() ] ]);
     });
 
-    it('displays the previous year if the current focused date is the first month of the year', () => {
-      wrapper.setProps({
+    it('displays the previous year if the current focused date is the first month of the year', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 0, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 0, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 0, 1)).getTime(),
@@ -85,13 +85,13 @@ describe('PickerMonth: changing focus', () => {
   });
 
   describe('focusNextQuarter', () => {
-    it('changes the focused date to the next quarter', () => {
-      wrapper.vm.focusNextQuarter();
+    it('changes the focused date to the next quarter', async () => {
+      await wrapper.vm.focusNextQuarter();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 4, 15)).getTime() ] ]);
     });
 
-    it('changes to the next year if the current focused date is the last quarter of the year', () => {
-      wrapper.setProps({
+    it('changes to the next year if the current focused date is the last quarter of the year', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 10, 11)).getTime(),
@@ -100,8 +100,8 @@ describe('PickerMonth: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2019, 1, 11)).getTime() ] ]);
     });
 
-    it('displays the next year if the current focused date is the last quarter of the year', () => {
-      wrapper.setProps({
+    it('displays the next year if the current focused date is the last quarter of the year', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 11, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 11, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 11, 26)).getTime(),
@@ -112,8 +112,8 @@ describe('PickerMonth: changing focus', () => {
   });
 
   describe('focusPreviousQuarter', () => {
-    it('changes the focused date to the previous quarter', () => {
-      wrapper.setProps({
+    it('changes the focused date to the previous quarter', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 11, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 11, 15)).getTime(),
       });
@@ -121,14 +121,14 @@ describe('PickerMonth: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 8, 15)).getTime() ] ]);
     });
 
-    it('changes to the previous year if the current focused date is the first quarter of the year', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 6)).getTime() });
+    it('changes to the previous year if the current focused date is the first quarter of the year', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2018, 1, 6)).getTime() });
       wrapper.vm.focusPreviousQuarter();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2017, 10, 6)).getTime() ] ]);
     });
 
-    it('displays the previous year if the current focused date is the first quarter of the year', () => {
-      wrapper.setProps({
+    it('displays the previous year if the current focused date is the first quarter of the year', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2018, 2, 1)),
         pageTimestamp: new Date(Date.UTC(2018, 2, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 2, 5)).getTime(),
@@ -140,7 +140,7 @@ describe('PickerMonth: changing focus', () => {
 
   it('focuses on the focused day when showing the month view', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('February');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: true,
       showMonthView: true,
     });
@@ -150,7 +150,7 @@ describe('PickerMonth: changing focus', () => {
 
   it('does not focus on the focused day when showing the month view before initializing', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('February');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: false,
       showMonthView: true,
     });

--- a/test/unit/specs/PickerMonth/disabledMonths.spec.js
+++ b/test/unit/specs/PickerMonth/disabledMonths.spec.js
@@ -1,11 +1,11 @@
 import PickerMonth from '@/components/PickerMonth.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerMonth', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerMonth, {
+    wrapper = shallowMount(PickerMonth, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -24,8 +24,8 @@ describe('PickerMonth', () => {
     expect(wrapper.vm.selectMonth(month)).toEqual(false);
   });
 
-  it('can accept a customPredictor to check if the month is disabled', () => {
-    wrapper.setProps({
+  it('can accept a customPredictor to check if the month is disabled', async () => {
+    await wrapper.setProps({
       disabledDates: {
         customPredictor (date) {
           if (date.getMonth() % 4 === 0) {

--- a/test/unit/specs/PickerMonth/pickerMonth.spec.js
+++ b/test/unit/specs/PickerMonth/pickerMonth.spec.js
@@ -1,11 +1,11 @@
 import PickerMonth from '@/components/PickerMonth.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerMonth', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerMonth, {
+    wrapper = shallowMount(PickerMonth, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -16,9 +16,9 @@ describe('PickerMonth', () => {
     });
   });
 
-  it('knows the selected month', () => {
+  it('knows the selected month', async () => {
     const newDate = new Date(2016, 9, 15);
-    wrapper.setProps({
+    await wrapper.setProps({
       selectedDate: newDate,
     });
     expect(wrapper.vm.isSelectedMonth(newDate)).toEqual(true);

--- a/test/unit/specs/PickerYear/changeFocus.spec.js
+++ b/test/unit/specs/PickerYear/changeFocus.spec.js
@@ -14,7 +14,7 @@ describe('PickerYear: changing focus', () => {
         focusedDate: new Date(Date.UTC(2018, 1, 15)).getTime(),
         useUtc: true,
       },
-      attachToDocument: true,
+      attachTo: document.body,
     });
   });
 
@@ -28,14 +28,14 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2019, 1, 15)).getTime() ] ]);
     });
 
-    it('changes to the next decade if the current focused date is the last year of the decade', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2019, 11, 28)).getTime() });
+    it('changes to the next decade if the current focused date is the last year of the decade', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2019, 11, 28)).getTime() });
       wrapper.vm.focusNextYear();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2020, 11, 28)).getTime() ] ]);
     });
 
-    it('displays the next decade if the current focused date is the last year of the decade', () => {
-      wrapper.setProps({
+    it('displays the next decade if the current focused date is the last year of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2010, 1, 1)),
         pageTimestamp: new Date(Date.UTC(2010, 1, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2019, 11, 28)).getTime(),
@@ -46,14 +46,14 @@ describe('PickerYear: changing focus', () => {
 
     it('focuses on the new focused year after it changes', async () => {
       // fake the .sync prop update
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2019, 1, 15)).getTime(),
       });
       wrapper.vm.focusNextYear();
       await wrapper.vm.$nextTick();
       expect(document.activeElement.textContent.trim()).toEqual('2019');
       wrapper.vm.focusNextYear();
-      wrapper.setProps({
+      await wrapper.setProps({
         focusedDate: new Date(Date.UTC(2020, 1, 15)).getTime(),
       });
       await wrapper.vm.$nextTick();
@@ -67,14 +67,14 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2017, 1, 15)).getTime() ] ]);
     });
 
-    it('changes to the previous decade if the current focused date is the first year of the decade', () => {
-      wrapper.setProps({ focusedDate: new Date(Date.UTC(2010, 0, 1)).getTime() });
+    it('changes to the previous decade if the current focused date is the first year of the decade', async () => {
+      await wrapper.setProps({ focusedDate: new Date(Date.UTC(2010, 0, 1)).getTime() });
       wrapper.vm.focusPreviousYear();
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2009, 0, 1)).getTime() ] ]);
     });
 
-    it('displays the previous decade if the current focused date is the first year of the decade', () => {
-      wrapper.setProps({
+    it('displays the previous decade if the current focused date is the first year of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2020, 0, 1)),
         pageTimestamp: new Date(Date.UTC(2020, 0, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2020, 0, 1)).getTime(),
@@ -85,8 +85,8 @@ describe('PickerYear: changing focus', () => {
   });
 
   describe('focusNextRow', () => {
-    it('changes the focused date to the next row', () => {
-      wrapper.setProps({
+    it('changes the focused date to the next row', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2015, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2015, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2015, 10, 11)).getTime(),
@@ -95,8 +95,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 10, 11)).getTime() ] ]);
     });
 
-    it('changes to the first year of the next decade if the current focused date is in the last year of the current decade', () => {
-      wrapper.setProps({
+    it('changes to the first year of the next decade if the current focused date is in the last year of the current decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2019, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2019, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2019, 10, 11)).getTime(),
@@ -105,8 +105,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2020, 10, 11)).getTime() ] ]);
     });
 
-    it('displays the next decade if the current focused date is the last year of the decade', () => {
-      wrapper.setProps({
+    it('displays the next decade if the current focused date is the last year of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2010, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2010, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2019, 10, 11)).getTime(),
@@ -115,8 +115,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('changedDecade')).toEqual([ [ new Date(Date.UTC(2020, 10, 1)) ] ]);
     });
 
-    it('changes to the first row of the next decade if the current focused date is in the last row with orphans of the current decade', () => {
-      wrapper.setProps({
+    it('changes to the first row of the next decade if the current focused date is in the last row with orphans of the current decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2017, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2017, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2017, 10, 11)).getTime(),
@@ -125,8 +125,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2021, 10, 11)).getTime() ] ]);
     });
 
-    it('displays the next decade if the current focused date is  in the the last row with orphans of the decade', () => {
-      wrapper.setProps({
+    it('displays the next decade if the current focused date is  in the the last row with orphans of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2010, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2010, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 10, 11)).getTime(),
@@ -137,8 +137,8 @@ describe('PickerYear: changing focus', () => {
   });
 
   describe('focusPreviousRow', () => {
-    it('changes the focused date to the previous row', () => {
-      wrapper.setProps({
+    it('changes the focused date to the previous row', async () => {
+      await wrapper.setProps({
         pageTimestamp: new Date(Date.UTC(2018, 11, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2018, 11, 15)).getTime(),
       });
@@ -146,8 +146,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2015, 11, 15)).getTime() ] ]);
     });
 
-    it('changes to the last year of the previous decade if the current focused date is in the first year of the current decade', () => {
-      wrapper.setProps({
+    it('changes to the last year of the previous decade if the current focused date is in the first year of the current decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2020, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2020, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2020, 10, 11)).getTime(),
@@ -156,8 +156,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2019, 10, 11)).getTime() ] ]);
     });
 
-    it('displays the previous decade if the current focused date is the first year of the decade', () => {
-      wrapper.setProps({
+    it('displays the previous decade if the current focused date is the first year of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2020, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2020, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2020, 10, 11)).getTime(),
@@ -166,8 +166,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('changedDecade')).toEqual([ [ new Date(Date.UTC(2010, 10, 1)) ] ]);
     });
 
-    it('changes to the first row of the previous decade if the current focused date is in the first row matching orphans of the current decade', () => {
-      wrapper.setProps({
+    it('changes to the first row of the previous decade if the current focused date is in the first row matching orphans of the current decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2020, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2020, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2022, 10, 11)).getTime(),
@@ -176,8 +176,8 @@ describe('PickerYear: changing focus', () => {
       expect(wrapper.emitted('update:focusedDate')).toEqual([ [ new Date(Date.UTC(2018, 10, 11)).getTime() ] ]);
     });
 
-    it('displays the previous decade if the current focused date is in the the first row matching orphans of the decade', () => {
-      wrapper.setProps({
+    it('displays the previous decade if the current focused date is in the the first row matching orphans of the decade', async () => {
+      await wrapper.setProps({
         pageDate: new Date(Date.UTC(2021, 10, 1)),
         pageTimestamp: new Date(Date.UTC(2021, 10, 1)).getTime(),
         focusedDate: new Date(Date.UTC(2021, 10, 11)).getTime(),
@@ -189,7 +189,7 @@ describe('PickerYear: changing focus', () => {
 
   it('focuses on the focused day when showing the year view', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('2018');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: true,
       showYearView: true,
     });
@@ -199,7 +199,7 @@ describe('PickerYear: changing focus', () => {
 
   it('does not focus on the focused day when showing the year view before initializing', async () => {
     expect(document.activeElement.textContent.trim()).not.toEqual('2018');
-    wrapper.setProps({
+    await wrapper.setProps({
       isInitialized: false,
       showYearView: true,
     });

--- a/test/unit/specs/PickerYear/disabledYears.spec.js
+++ b/test/unit/specs/PickerYear/disabledYears.spec.js
@@ -1,11 +1,11 @@
 import PickerYear from '@/components/PickerYear.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerYear', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerYear, {
+    wrapper = shallowMount(PickerYear, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -29,8 +29,8 @@ describe('PickerYear', () => {
     expect(wrapper.vm.nextDecade()).toEqual(false);
   });
 
-  it('can\'t change decade when previous or next decades are disabled', () => {
-    wrapper.setProps({
+  it('can\'t change decade when previous or next decades are disabled', async () => {
+    await wrapper.setProps({
       pageDate: new Date(2016, 9, 15),
       disabledDates: {
         to: new Date(2010, 8, 6),
@@ -41,8 +41,8 @@ describe('PickerYear', () => {
     expect(wrapper.vm.isNextDecadeDisabled()).toEqual(true);
   });
 
-  it('can change decade despite having a disabled decade', () => {
-    wrapper.setProps({
+  it('can change decade despite having a disabled decade', async () => {
+    await wrapper.setProps({
       pageDate: new Date(2016, 9, 15),
       disabledDates: {
         to: new Date(2010, 11, 19),
@@ -53,8 +53,8 @@ describe('PickerYear', () => {
     expect(wrapper.vm.isNextDecadeDisabled()).toEqual(false);
   });
 
-  it('can accept a customPredictor to check if the year is disabled', () => {
-    wrapper.setProps({
+  it('can accept a customPredictor to check if the year is disabled', async () => {
+    await wrapper.setProps({
       disabledDates: {
         customPredictor (date) {
           if (date.getFullYear() % 3 === 0) {
@@ -70,8 +70,8 @@ describe('PickerYear', () => {
     expect(wrapper.vm.isDisabledYear(new Date(2022, 2, 11))).toEqual(true);
   });
 
-  it('does not disable the next decade button when disabled from date is in the first year of the next decade', () => {
-    wrapper.setProps({
+  it('does not disable the next decade button when disabled from date is in the first year of the next decade', async () => {
+    await wrapper.setProps({
       pageDate: new Date(1998, 9, 15),
       disabledDates: {
         from: new Date(2000, 0, 1),
@@ -80,8 +80,8 @@ describe('PickerYear', () => {
     expect(wrapper.vm.isNextDecadeDisabled()).toEqual(false);
   });
 
-  it('does disable the next decade button when disabled from date is the last day year of the current decade', () => {
-    wrapper.setProps({
+  it('does disable the next decade button when disabled from date is the last day year of the current decade', async () => {
+    await wrapper.setProps({
       disabledDates: {
         from: new Date(1999, 12, 31),
       },

--- a/test/unit/specs/PickerYear/pickerYear.spec.js
+++ b/test/unit/specs/PickerYear/pickerYear.spec.js
@@ -1,11 +1,11 @@
 import PickerYear from '@/components/PickerYear.vue';
-import { shallow } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { en } from '@/locale';
 
 describe('PickerYear', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = shallow(PickerYear, {
+    wrapper = shallowMount(PickerYear, {
       propsData: {
         allowedToShowView: () => true,
         translation: en,
@@ -15,9 +15,9 @@ describe('PickerYear', () => {
     });
   });
 
-  it('knows the selected year', () => {
+  it('knows the selected year', async () => {
     const newDate = new Date(2016, 9, 15);
-    wrapper.setProps({
+    await wrapper.setProps({
       selectedDate: newDate,
     });
     expect(wrapper.vm.isSelectedYear(newDate)).toEqual(true);
@@ -34,12 +34,12 @@ describe('PickerYear', () => {
     expect(wrapper.emitted().changedDecade).toBeTruthy();
   });
 
-  it('formats the decade range', () => {
-    wrapper.setProps({
+  it('formats the decade range', async () => {
+    await wrapper.setProps({
       pageDate: new Date(2021, 1, 1),
     });
     expect(wrapper.vm.getPageDecade).toEqual('2020 - 2029');
-    wrapper.setProps({
+    await wrapper.setProps({
       pageDate: new Date(2001, 1, 1),
     });
     expect(wrapper.vm.getPageDecade).toEqual('2000 - 2009');


### PR DESCRIPTION
We updated Vue to v2.7, and then tests were failing due to incompatibilities with the Vue Test Utils version we were using (1.0.0 beta), so we updated those as well.

This change consists mostly of 3 things:
- Replace the deprecated `shallow` with `shallowMount`.
- Replace the deprecated `attachToDocument` option with `attachTo`.
- Add an `await` before every `wrapper.setProps` or `wrapper.setData`. 