### PR TITLE
♿ Open datepicker when pressing enter or space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-1.6.3",
+  "version": "1.6.2-reedsy-1.6.4",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "keywords": [
     "vue",

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -38,7 +38,7 @@
       :aria-controls="dropdownId"
       @click="showCalendar"
       @keyup="parseTypedDate"
-      @keydown.down.prevent="showCalendar"
+      @keydown.down.space.enter.prevent="showCalendar"
       @blur="inputBlurred"
     >
     <!-- Clear Button -->


### PR DESCRIPTION
According to the WAI-ARIA guidelines, dropdowns are open with the arrow keys, space and enter (and others, but we haven't implemented those yet)
<img width="834" alt="imagen" src="https://user-images.githubusercontent.com/8100755/184321336-fe585c9d-7039-44a8-8af6-6ceabaf4d43a.png">

On the other hand, in those same guidelines, the date picker is open only with the down arrow
<img width="863" alt="imagen" src="https://user-images.githubusercontent.com/8100755/184321487-dee3b219-22b3-43b4-97b7-2516fcde64d0.png">

While we initially followed these guidelines, this really is inconsistent and it doesn't make much sense, since these two are basically the same control (although they show different content when open). Also, binding these keys doesn't really hurt, so it's probably a good idea to do so for a more consistent UX.
