### PR TITLE
Fix picker losing current selection on close after click outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-1.6.7",
+  "version": "1.6.2-reedsy-1.6.8",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "keywords": [
     "vue",

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -339,7 +339,6 @@ export default {
      */
     clickOutside (event) {
       if (this.$el && !this.$el.contains(event.target)) {
-        this.resetDefaultPageDate();
         this.close(true);
         document.removeEventListener('click', this.clickOutside, false);
       }
@@ -361,17 +360,6 @@ export default {
         event.preventDefault();
         lastFocusableElement.focus();
       }
-    },
-    /**
-     * Called in the event that the user navigates to date pages and
-     * closes the picker without selecting a date.
-     */
-    resetDefaultPageDate () {
-      if (this.selectedDate === null) {
-        this.setPageDate();
-        return;
-      }
-      this.setPageDate(this.selectedDate);
     },
     /**
      * Effectively a toggle to show/hide the calendar

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -194,32 +194,6 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.showMonthView).toEqual(true);
   });
 
-  it('resets the default page date', () => {
-    const wrapper = shallowMount(Datepicker);
-    const today = new Date();
-    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());
-    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth());
-    expect(wrapper.vm.pageDate.getDate()).toEqual(1);
-    wrapper.vm.resetDefaultPageDate();
-    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());
-    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth());
-    expect(wrapper.vm.pageDate.getDate()).toEqual(1);
-  });
-
-  it('does not set the default page date if a date is selected', () => {
-    const wrapper = shallowMount(Datepicker);
-    const today = new Date();
-    const pastDate = new Date(2018, 3, 20);
-    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear());
-    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth());
-    expect(wrapper.vm.pageDate.getDate()).toEqual(1);
-    wrapper.vm.setDate(pastDate.getTime());
-    wrapper.vm.resetDefaultPageDate();
-    expect(wrapper.vm.pageDate.getFullYear()).toEqual(pastDate.getFullYear());
-    expect(wrapper.vm.pageDate.getMonth()).toEqual(pastDate.getMonth());
-    expect(wrapper.vm.pageDate.getDate()).toEqual(1);
-  });
-
   it('sets the date on typedDate event', () => {
     const wrapper = shallowMount(Datepicker);
     const today = new Date();


### PR DESCRIPTION
Currently, there is a bug in month/year pickers, here are steps to reproduce it: 
1. open a month picker 
2. go from January to March and click outside to close it
3. open the picker again (you land on January)
4. click next month and you will end up on April instead of February.

This happens because we modify `pageTimestamp` value on click-outside.

This PR aligns the Datepicker behaviour of click-outside closing with click-on-input closing behaviour, so we stop modifying  `pageTimestamp` which seems unnecessary.