### PR TITLE
Remove input blur on Enter or Escape key press

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-2.1.6",
+  "version": "1.6.2-reedsy-2.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@reedsy/vuejs-datepicker",
-      "version": "1.6.2-reedsy-2.1.6",
+      "version": "1.6.2-reedsy-2.1.8",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-2.1.7",
+  "version": "1.6.2-reedsy-2.1.8",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "keywords": [
     "vue",

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -145,17 +145,8 @@ export default {
     },
     /**
      * Attempt to parse a typed date
-     * @param {Event} event
      */
-    parseTypedDate (event) {
-      // close calendar if escape or enter are pressed
-      if ([
-        27, // escape
-        13, // enter
-      ].includes(event.keyCode)) {
-        this.input.blur();
-      }
-
+    parseTypedDate () {
       if (this.typeable) {
         const typedDate = Date.parse(this.input.value);
         if (!isNaN(typedDate)) {

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -37,13 +37,6 @@ describe('DateInput', () => {
     expect(wrapper.emitted().typedDate[0][0]).toBeInstanceOf(Date);
   });
 
-  it('emits closeCalendar when return is pressed', () => {
-    const input = wrapper.find('input');
-    const blurSpy = jest.spyOn(input.element, 'blur');
-    input.trigger('keyup', { keyCode: 13 });
-    expect(blurSpy).toBeCalled();
-  });
-
   it('clears a typed date if it does not parse', async () => {
     const input = wrapper.find('input');
     await wrapper.setData({ typedDate: 'not a date' });


### PR DESCRIPTION
Removes the blur behavior on the Datepicker input when pressing the `Enter` or `Escape` keys.

Currently, this leads to an odd user experience where the input loses focus after the Datepicker closes. It seems that this behavior is a remnant of a [previous implementation](https://github.com/charliekassel/vuejs-datepicker/commit/844e59c03022bce988682e995a861efb17c83ee5#diff-fcd39cd1efe9cd67481d8aae3e448c6932e32ce217ab053de9622e28d2e2186dL93) that used to close the calendar upon `Enter` or `Escape` keypresses, which is no longer necessary in Reedsy fork. The Datepicker already closes by other means, so maintaining the input focus offers a better UX.