### PR TITLE
Fix openDate update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/vuejs-datepicker",
-  "version": "1.6.2-reedsy-2.1.10",
+  "version": "1.6.2-reedsy-2.1.11",
   "description": "A simple Vue.js datepicker component. Supports disabling of dates, inline mode, translations",
   "keywords": [
     "vue",

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -159,6 +159,7 @@
     </picker-year>
   </div>
 </template>
+
 <script>
 import en from '../locale/translations/en';
 import DateInput from './DateInput.vue';
@@ -322,7 +323,10 @@ export default {
     },
     openDate () {
       this.setPageDate();
-      this.focusedDate = this.openDate.getTime();
+
+      this.focusedDate = this.openDate ?
+        this.openDate.getTime() :
+        new Date().getTime();
     },
     initialView () {
       this.setInitialView();
@@ -622,6 +626,7 @@ export default {
       if (this.modelValue) {
         this.setValue(this.modelValue);
       }
+
       if (this.isInline) {
         this.setInitialView();
       }

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -241,17 +241,40 @@ describe('Datepicker mounted', () => {
     expect(spy).toBeCalled();
   });
 
-  it('watches openDate', async () => {
-    const wrapper = shallowMount(Datepicker, {
-      propsData: {
-        openDate: new Date(2018, 0, 1),
-      },
+  describe('openDate watcher', () => {
+    it('should update the pageTimestamp and focusedDate', async () => {
+      const wrapper = shallowMount(Datepicker, {
+        propsData: {
+          openDate: new Date(2018, 0, 1),
+        },
+      });
+      expect(wrapper.vm.focusedDate).toEqual(new Date(2018, 0, 1).getTime());
+      expect(wrapper.vm.pageTimestamp).toEqual(new Date(2018, 0, 1).getTime());
+      const spy = jest.spyOn(wrapper.vm, 'setPageDate');
+      await wrapper.setProps({
+        openDate: new Date(2018, 3, 26),
+      });
+      expect(spy).toBeCalled();
+      expect(wrapper.vm.focusedDate).toEqual(new Date(2018, 3, 26).getTime());
+      expect(wrapper.vm.pageTimestamp).toEqual(new Date(2018, 3, 1).getTime());
     });
-    const spy = jest.spyOn(wrapper.vm, 'setPageDate');
-    await wrapper.setProps({
-      openDate: new Date(2018, 3, 26),
+
+    it('Should not crash when openDate is cleared', async () => {
+      const wrapper = shallowMount(Datepicker, {
+        propsData: {
+          openDate: new Date(2018, 0, 1),
+        },
+      });
+      expect(wrapper.vm.focusedDate).toEqual(new Date(2018, 0, 1).getTime());
+      expect(wrapper.vm.pageTimestamp).toEqual(new Date(2018, 0, 1).getTime());
+      const spy = jest.spyOn(wrapper.vm, 'setPageDate');
+      await wrapper.setProps({
+        openDate: null,
+      });
+      expect(spy).toBeCalled();
+      expect(wrapper.vm.focusedDate).not.toEqual(new Date(2018, 0, 1).getTime());
+      expect(wrapper.vm.pageTimestamp).not.toEqual(new Date(2018, 0, 1).getTime());
     });
-    expect(spy).toBeCalled();
   });
 
   it('watches initialView', async () => {


### PR DESCRIPTION
In the current implementation, when the openDate is cleared it makes the component crash.