### PR TITLE
Fix typo: replace --ignore-script with --ignore-scripts in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           scope: "@reedsy"
       - name: Install
         # Skip post-install to avoid malicious scripts stealing PAT
-        run: npm install --ignore-script
+        run: npm install --ignore-scripts
         env:
           # GITHUB_TOKEN can't access packages hosted in private repos,
           # even within the same organisation


### PR DESCRIPTION
## Summary

- Fixes a typo: `--ignore-script` → `--ignore-scripts` in CI workflows
- `--ignore-script` is not a valid npm flag and is silently ignored
- `--ignore-scripts` (plural) is the correct flag, per the [npm install docs](https://docs.npmjs.com/cli/v10/commands/npm-install#ignore-scripts)

## Test plan

- [ ] Verify CI passes after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)